### PR TITLE
LINE友だち追加ボタンをContactセクションとFooterに追加

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,6 +10,10 @@ const nextConfig = {
         protocol: "https",
         hostname: "images.microcms-assets.io",
       },
+      {
+        protocol: "https",
+        hostname: "scdn.line-apps.com",
+      },
     ],
   },
   logging: {

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/use-toast";
 import { submitContactForm, ContactFormState } from "@/actions/contact";
 import { Send, Mail, User, MessageSquare, X } from "lucide-react";
-import Image from "next/image";
+import LineAddFriendButton from "@/components/LineAddFriendButton";
 
 // リソース状況テーブルの設定
 const RESOURCES = [
@@ -253,19 +253,7 @@ export default function Component() {
                   <p className="text-xs text-gray-500 leading-relaxed">
                     LINEからもお気軽にご相談いただけます。
                   </p>
-                  <a
-                    href="https://lin.ee/qK9z3Wk"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <Image
-                      src="https://scdn.line-apps.com/n/line_add_friends/btn/ja.png"
-                      alt="友だち追加"
-                      width={104}
-                      height={28}
-                      unoptimized
-                    />
-                  </a>
+                  <LineAddFriendButton />
                 </div>
               </div>
             </div>

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/use-toast";
 import { submitContactForm, ContactFormState } from "@/actions/contact";
 import { Send, Mail, User, MessageSquare, X } from "lucide-react";
+import Image from "next/image";
 
 // リソース状況テーブルの設定
 const RESOURCES = [
@@ -233,6 +234,40 @@ export default function Component() {
                   </div>
                 </div>
               ))}
+
+              {/* LINE友だち追加 */}
+              <div className="flex gap-3 p-4 rounded-xl bg-white border border-gray-100">
+                <div className="shrink-0 w-8 h-8 flex items-center justify-center rounded-lg bg-green-50">
+                  <svg
+                    className="w-4 h-4 text-green-500"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                  >
+                    <path d="M12 2C6.48 2 2 6.03 2 11c0 2.7 1.26 5.12 3.25 6.79L4.5 22l4.36-2.28C9.85 19.89 10.91 20 12 20c5.52 0 10-4.03 10-9s-4.48-9-10-9z" />
+                  </svg>
+                </div>
+                <div className="flex flex-col gap-2">
+                  <p className="text-sm font-semibold text-gray-800">
+                    LINEで相談
+                  </p>
+                  <p className="text-xs text-gray-500 leading-relaxed">
+                    LINEからもお気軽にご相談いただけます。
+                  </p>
+                  <a
+                    href="https://lin.ee/qK9z3Wk"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Image
+                      src="https://scdn.line-apps.com/n/line_add_friends/btn/ja.png"
+                      alt="友だち追加"
+                      width={104}
+                      height={28}
+                      unoptimized
+                    />
+                  </a>
+                </div>
+              </div>
             </div>
           </div>
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -89,6 +89,25 @@ const Footer = () => {
                 </Link>
               ))}
             </div>
+
+            <div className="flex flex-col gap-3">
+              <p className="text-xs font-semibold tracking-widest text-gray-500 uppercase mb-1">
+                LINE
+              </p>
+              <a
+                href="https://lin.ee/qK9z3Wk"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Image
+                  src="https://scdn.line-apps.com/n/line_add_friends/btn/ja.png"
+                  alt="友だち追加"
+                  width={104}
+                  height={28}
+                  unoptimized
+                />
+              </a>
+            </div>
           </div>
         </div>
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,6 +5,7 @@ import { Link as Scroll } from "react-scroll";
 import { usePathname } from "next/navigation";
 import config from "@/config";
 import Image from "next/image";
+import LineAddFriendButton from "@/components/LineAddFriendButton";
 
 const navLinks = [
   { label: "トップ", to: "hero", href: "/" },
@@ -94,19 +95,7 @@ const Footer = () => {
               <p className="text-xs font-semibold tracking-widest text-gray-500 uppercase mb-1">
                 LINE
               </p>
-              <a
-                href="https://lin.ee/qK9z3Wk"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <Image
-                  src="https://scdn.line-apps.com/n/line_add_friends/btn/ja.png"
-                  alt="友だち追加"
-                  width={104}
-                  height={28}
-                  unoptimized
-                />
-              </a>
+              <LineAddFriendButton />
             </div>
           </div>
         </div>

--- a/src/components/LineAddFriendButton.tsx
+++ b/src/components/LineAddFriendButton.tsx
@@ -1,18 +1,14 @@
 import Image from "next/image";
 
-interface Props {
+type Props = {
   height?: number;
-}
+};
 
 const LineAddFriendButton = ({ height = 28 }: Props) => {
   const width = Math.round((104 / 28) * height);
 
   return (
-    <a
-      href="https://lin.ee/qK9z3Wk"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
+    <a href="https://lin.ee/qK9z3Wk" target="_blank" rel="noopener noreferrer">
       <Image
         src="https://scdn.line-apps.com/n/line_add_friends/btn/ja.png"
         alt="友だち追加"

--- a/src/components/LineAddFriendButton.tsx
+++ b/src/components/LineAddFriendButton.tsx
@@ -1,0 +1,27 @@
+import Image from "next/image";
+
+interface Props {
+  height?: number;
+}
+
+const LineAddFriendButton = ({ height = 28 }: Props) => {
+  const width = Math.round((104 / 28) * height);
+
+  return (
+    <a
+      href="https://lin.ee/qK9z3Wk"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <Image
+        src="https://scdn.line-apps.com/n/line_add_friends/btn/ja.png"
+        alt="友だち追加"
+        width={width}
+        height={height}
+        unoptimized
+      />
+    </a>
+  );
+};
+
+export default LineAddFriendButton;


### PR DESCRIPTION
## Summary

- Contact セクションの左側案内カードに「LINEで相談」カードを追加（公式友だち追加ボタン付き）
- Footer のナビゲーション列に LINE 友だち追加ボタンを追加
- `next.config.mjs` に `scdn.line-apps.com` を `remotePatterns` へ追加し、`<Image />` コンポーネントで最適化対応

## Test plan

- [ ] トップページの Contact セクションに「LINEで相談」カードが表示されることを確認
- [ ] Footer に LINE 友だち追加ボタンが表示されることを確認
- [ ] ボタンクリックで `https://lin.ee/qK9z3Wk` が新しいタブで開くことを確認
- [ ] ESLint の `no-img-element` 警告が出ないことを確認（`npm run lint`）
- [ ] モバイル表示でレイアウトが崩れないことを確認