### PR TITLE
ボタンのborder-radiusをrounded-smに変更

### DIFF
--- a/src/app/coming-soon/page.tsx
+++ b/src/app/coming-soon/page.tsx
@@ -60,7 +60,7 @@ const ComingSoon = () => {
           <Link href="/">
             <Button
               size="lg"
-              className="bg-gray-950 text-white hover:bg-gray-800 transition-all duration-300 px-8 rounded-xl font-semibold tracking-wide inline-flex items-center gap-2"
+              className="bg-gray-950 text-white hover:bg-gray-800 transition-all duration-300 px-8 rounded-sm font-semibold tracking-wide inline-flex items-center gap-2"
             >
               <ArrowLeft className="w-4 h-4" />
               トップページへ

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -342,7 +342,7 @@ export default function Component() {
 
                 <div className="flex justify-end pt-2">
                   <Button
-                    className="px-8 rounded-xl font-semibold bg-gray-950 hover:bg-gray-800 text-white transition-all duration-300"
+                    className="px-8 rounded-sm font-semibold bg-gray-950 hover:bg-gray-800 text-white transition-all duration-300"
                     type="submit"
                   >
                     <Send className="w-4 h-4 mr-2" />
@@ -376,14 +376,14 @@ export default function Component() {
                 type="button"
                 variant="outline"
                 onClick={() => setShowModal(false)}
-                className="rounded-xl px-6 border-gray-200"
+                className="rounded-sm px-6 border-gray-200"
               >
                 キャンセル
               </Button>
               <Button
                 type="button"
                 onClick={handleConfirmedSubmit}
-                className="rounded-xl px-6 bg-gray-950 hover:bg-gray-800 text-white"
+                className="rounded-sm px-6 bg-gray-950 hover:bg-gray-800 text-white"
               >
                 送信する
               </Button>

--- a/src/components/CtaBanner.tsx
+++ b/src/components/CtaBanner.tsx
@@ -33,7 +33,7 @@ const CtaBanner = () => {
           <Scroll to="contact" smooth={true} offset={-100} className="relative z-10">
             <Button
               size="lg"
-              className="bg-cyan-600 text-white hover:bg-cyan-500 font-semibold transition-all duration-300 px-10 rounded-xl"
+              className="bg-cyan-600 text-white hover:bg-cyan-500 font-semibold transition-all duration-300 px-10 rounded-sm"
             >
               ご相談はこちら
             </Button>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -116,7 +116,7 @@ const Header = () => {
               <Scroll to="contact" smooth={true} offset={-100}>
                 <Button
                   size="sm"
-                  className="rounded-xl px-5 bg-gray-950 text-white hover:bg-gray-800 transition-all duration-300 font-semibold"
+                  className="rounded-sm px-5 bg-gray-950 text-white hover:bg-gray-800 transition-all duration-300 font-semibold"
                 >
                   お問い合わせ
                 </Button>
@@ -125,7 +125,7 @@ const Header = () => {
               <Link href="/#contact">
                 <Button
                   size="sm"
-                  className="rounded-xl px-5 bg-gray-950 text-white hover:bg-gray-800 transition-all duration-300 font-semibold"
+                  className="rounded-sm px-5 bg-gray-950 text-white hover:bg-gray-800 transition-all duration-300 font-semibold"
                 >
                   お問い合わせ
                 </Button>
@@ -231,13 +231,13 @@ const Header = () => {
                     offset={-40}
                     onClick={closeMenu}
                   >
-                    <Button className="w-full rounded-xl bg-cyan-600 hover:bg-cyan-500 text-white font-semibold transition-all duration-300">
+                    <Button className="w-full rounded-sm bg-cyan-600 hover:bg-cyan-500 text-white font-semibold transition-all duration-300">
                       お問い合わせ
                     </Button>
                   </Scroll>
                 ) : (
                   <Link href="/#contact" onClick={closeMenu}>
-                    <Button className="w-full rounded-xl bg-cyan-600 hover:bg-cyan-500 text-white font-semibold transition-all duration-300">
+                    <Button className="w-full rounded-sm bg-cyan-600 hover:bg-cyan-500 text-white font-semibold transition-all duration-300">
                       お問い合わせ
                     </Button>
                   </Link>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -92,7 +92,7 @@ const Hero = () => {
               <Scroll to="contact" smooth={true} offset={-100}>
                 <Button
                   size="lg"
-                  className="bg-gray-950 text-white hover:bg-gray-800 transition-all duration-300 px-8 rounded-xl font-semibold tracking-wide"
+                  className="bg-gray-950 text-white hover:bg-gray-800 transition-all duration-300 px-8 rounded-sm font-semibold tracking-wide"
                 >
                   お問い合わせ
                 </Button>
@@ -101,7 +101,7 @@ const Hero = () => {
                 <Button
                   size="lg"
                   variant="outline"
-                  className="border-gray-300 text-gray-700 hover:border-gray-950 hover:text-gray-950 transition-all duration-300 px-8 rounded-xl"
+                  className="border-gray-300 text-gray-700 hover:border-gray-950 hover:text-gray-950 transition-all duration-300 px-8 rounded-sm"
                 >
                   サービスを見る
                 </Button>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-sm text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
@@ -21,8 +21,8 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        sm: "h-9 rounded-sm px-3",
+        lg: "h-11 rounded-sm px-8",
         icon: "h-10 w-10",
       },
     },


### PR DESCRIPTION
## Summary

- `src/components/ui/button.tsx` のベースクラス・sm/lg サイズバリアントの `rounded-md` を `rounded-sm`（2px）に変更
- Hero、Header、Contact、CtaBanner、coming-soon ページの各ボタンで個別指定されていた `rounded-xl`（20px）を `rounded-sm` に統一

## Test plan

- [ ] トップページのボタン（Hero・Header・CtaBanner・Contact）が角張ったデザインになっていること
- [ ] モバイルメニューのボタンも同様に変更されていること
- [ ] coming-soon ページのボタンが変更されていること
- [ ] カード・コンテナなどボタン以外の要素の角丸に影響がないこと