### PR TITLE
デザイン全体の角丸をシャープなスタイルに統一

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -99,7 +99,7 @@ const AboutPage = () => {
           <div className="flex flex-col lg:flex-row gap-10 lg:gap-16">
             {/* マップ */}
             <div className="w-full lg:w-1/2 shrink-0">
-              <div className="rounded-2xl overflow-hidden border border-gray-100 shadow-sm">
+              <div className="rounded-lg overflow-hidden border border-gray-100 shadow-sm">
                 <iframe
                   src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d6635.037567898468!2d129.67908911499234!3d33.74725761365943!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x356a152dd77d1c2b%3A0xf76c730b62764b90!2z44CSODExLTUxMzUg6ZW35bSO55yM5aOx5bKQ5biC6YO344OO5rWm55S66YO344OO5rWm!5e0!3m2!1sja!2sjp!4v1723188274913!5m2!1sja!2sjp"
                   width="100%"
@@ -153,7 +153,7 @@ const AboutPage = () => {
             {members.map((member) => (
               <div
                 key={member.name}
-                className="flex flex-col md:flex-row gap-8 md:gap-12 items-start bg-white rounded-2xl p-8 border border-gray-100"
+                className="flex flex-col md:flex-row gap-8 md:gap-12 items-start bg-white rounded-lg p-8 border border-gray-100"
               >
                 {/* 画像 */}
                 {/* <div className="shrink-0">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,7 +23,7 @@
     --border: 20 5.9% 90%;
     --input: 20 5.9% 90%;
     --ring: 20 14.3% 4.1%;
-    --radius: 0.5rem;
+    --radius: 0.25rem;
   }
 
   .dark {

--- a/src/app/news/[slug]/page.tsx
+++ b/src/app/news/[slug]/page.tsx
@@ -131,7 +131,7 @@ const NewsDetailPage = async ({ params }: { params: { slug: string } }) => {
       {/* 記事本文 */}
       <div className="max-w-4xl mx-auto px-6 lg:px-12 py-16">
         {data.thumbnail && (
-          <div className="mb-12 rounded-2xl overflow-hidden">
+          <div className="mb-12 rounded-lg overflow-hidden">
             <Image
               src={data.thumbnail.url}
               alt={data.title}
@@ -143,7 +143,7 @@ const NewsDetailPage = async ({ params }: { params: { slug: string } }) => {
           </div>
         )}
 
-        <article className="prose prose-slate max-w-none prose-headings:font-bold prose-headings:tracking-tight prose-a:text-cyan-600 prose-a:no-underline hover:prose-a:underline prose-img:rounded-xl prose-pre:rounded-xl">
+        <article className="prose prose-slate max-w-none prose-headings:font-bold prose-headings:tracking-tight prose-a:text-cyan-600 prose-a:no-underline hover:prose-a:underline prose-img:rounded-md prose-pre:rounded-md">
           {content}
         </article>
 

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -79,7 +79,7 @@ const NewsListPage = async ({
                 <Link
                   key={news.id}
                   href={`/news/${news.id}`}
-                  className="group flex flex-col sm:flex-row sm:items-center gap-4 py-7 hover:bg-gray-50/80 -mx-4 px-4 rounded-xl transition-colors duration-200"
+                  className="group flex flex-col sm:flex-row sm:items-center gap-4 py-7 hover:bg-gray-50/80 -mx-4 px-4 rounded-md transition-colors duration-200"
                 >
                   <time
                     className="shrink-0 text-sm font-medium text-gray-400 w-28"
@@ -107,7 +107,7 @@ const NewsListPage = async ({
             )}
           </>
         ) : (
-          <div className="rounded-2xl border border-dashed border-gray-200 bg-gray-50 py-24 px-6 flex flex-col items-center gap-4 text-center">
+          <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 py-24 px-6 flex flex-col items-center gap-4 text-center">
             <div className="flex items-center gap-2">
               <span className="w-8 h-px bg-cyan-600" />
               <span className="text-xs font-semibold tracking-widest text-cyan-600 uppercase">

--- a/src/app/services/dx-ai-support/_DxAiSupportContent.tsx
+++ b/src/app/services/dx-ai-support/_DxAiSupportContent.tsx
@@ -238,7 +238,7 @@ const DxAiSupportContent = () => {
                   whileInView={{ opacity: 1, x: 0 }}
                   viewport={{ once: true }}
                   transition={{ duration: 0.4, delay: index * 0.1 }}
-                  className="flex items-start gap-3 bg-white rounded-xl p-4 shadow-sm border border-amber-100"
+                  className="flex items-start gap-3 bg-white rounded-md p-4 shadow-sm border border-amber-100"
                 >
                   <CheckCircle className="w-5 h-5 text-gray-300 flex-shrink-0 mt-0.5" />
                   <span className="text-gray-700 text-sm leading-relaxed">{concern}</span>
@@ -277,7 +277,7 @@ const DxAiSupportContent = () => {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.5, delay: index * 0.1 }}
-                className="flex gap-4 p-6 rounded-xl border border-gray-100 bg-gray-50 hover:border-cyan-200 hover:bg-cyan-50/30 transition-colors duration-300"
+                className="flex gap-4 p-6 rounded-md border border-gray-100 bg-gray-50 hover:border-cyan-200 hover:bg-cyan-50/30 transition-colors duration-300"
               >
                 <div className="flex-shrink-0 w-12 h-12 bg-white rounded-full flex items-center justify-center shadow-sm">
                   {item.icon}
@@ -317,7 +317,7 @@ const DxAiSupportContent = () => {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.5, delay: index * 0.08 }}
-                className="bg-white rounded-xl p-6 border-l-4 border-cyan-400 shadow-sm hover:shadow-md transition-shadow duration-300"
+                className="bg-white rounded-md p-6 border-l-4 border-cyan-400 shadow-sm hover:shadow-md transition-shadow duration-300"
               >
                 <div className="text-2xl mb-3">{topic.icon}</div>
                 <h3 className="text-base font-bold text-gray-900 mb-2">{topic.title}</h3>
@@ -395,7 +395,7 @@ const DxAiSupportContent = () => {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.4, delay: index * 0.08 }}
-                className="bg-white border border-gray-200 rounded-xl p-6 hover:border-cyan-200 transition-colors duration-300"
+                className="bg-white border border-gray-200 rounded-md p-6 hover:border-cyan-200 transition-colors duration-300"
               >
                 <h3 className="text-base font-bold text-gray-900 mb-3 flex items-start gap-2">
                   <span className="text-cyan-600 font-bold text-lg leading-none mt-0.5">Q.</span>

--- a/src/app/services/it-training/_ItTrainingContent.tsx
+++ b/src/app/services/it-training/_ItTrainingContent.tsx
@@ -139,7 +139,7 @@ const ItTrainingContent = () => {
               className="flex flex-row lg:flex-col gap-4 flex-shrink-0"
             >
               {highlights.map((h) => (
-                <div key={h.label} className="bg-white border border-cyan-200 rounded-xl px-6 py-4 text-center min-w-[100px] shadow-sm">
+                <div key={h.label} className="bg-white border border-cyan-200 rounded-md px-6 py-4 text-center min-w-[100px] shadow-sm">
                   <div className="text-2xl font-black text-cyan-600">{h.value}</div>
                   <div className="text-gray-500 text-xs mt-1">{h.label}</div>
                 </div>
@@ -164,7 +164,7 @@ const ItTrainingContent = () => {
             </h2>
             <p className="text-gray-600 text-base md:text-lg">組み合わせ・カスタマイズも可能です。</p>
           </motion.div>
-          <div className="border border-gray-200 rounded-2xl overflow-hidden">
+          <div className="border border-gray-200 rounded-lg overflow-hidden">
             {menuItems.map((item, index) => (
               <motion.div
                 key={index}
@@ -214,7 +214,7 @@ const ItTrainingContent = () => {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.5, delay: index * 0.1 }}
-                className="bg-white rounded-xl border-t-4 border-cyan-400 p-6 shadow-sm hover:shadow-md transition-shadow duration-300"
+                className="bg-white rounded-md border-t-4 border-cyan-400 p-6 shadow-sm hover:shadow-md transition-shadow duration-300"
               >
                 <div className="w-12 h-12 bg-cyan-50 rounded-lg flex items-center justify-center mb-4">
                   {point.icon}
@@ -259,7 +259,7 @@ const ItTrainingContent = () => {
                     className={`flex items-center gap-8 ${isLeft ? "flex-row" : "flex-row-reverse"}`}
                   >
                     <div className="flex-1">
-                      <div className={`bg-white border border-cyan-100 rounded-xl p-6 shadow-sm hover:border-cyan-300 transition-colors ${isLeft ? "text-right" : "text-left"}`}>
+                      <div className={`bg-white border border-cyan-100 rounded-md p-6 shadow-sm hover:border-cyan-300 transition-colors ${isLeft ? "text-right" : "text-left"}`}>
                         <div className="text-xs text-cyan-500 font-medium mb-1">STEP {index + 1}</div>
                         <h3 className="text-lg font-bold text-gray-900 mb-2">{step.title}</h3>
                         <p className="text-gray-600 text-sm leading-relaxed">{step.description}</p>
@@ -347,7 +347,7 @@ const ItTrainingContent = () => {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.4, delay: index * 0.06 }}
-                className="border border-gray-200 rounded-xl overflow-hidden"
+                className="border border-gray-200 rounded-md overflow-hidden"
               >
                 <button
                   onClick={() => setOpenFaq(openFaq === index ? null : index)}

--- a/src/app/services/programming-school/_ProgrammingSchoolContent.tsx
+++ b/src/app/services/programming-school/_ProgrammingSchoolContent.tsx
@@ -146,7 +146,7 @@ const ProgrammingSchoolContent = () => {
               transition={{ duration: 0.7, delay: 0.2 }}
               className="flex-shrink-0 w-full max-w-xs lg:max-w-sm font-mono"
             >
-              <div className="bg-slate-700 rounded-xl overflow-hidden shadow-2xl border border-slate-600">
+              <div className="bg-slate-700 rounded-md overflow-hidden shadow-2xl border border-slate-600">
                 <div className="flex items-center gap-2 px-4 py-3 bg-slate-600">
                   <div className="w-3 h-3 rounded-full bg-red-500/70" />
                   <div className="w-3 h-3 rounded-full bg-yellow-500/70" />
@@ -189,7 +189,7 @@ const ProgrammingSchoolContent = () => {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.5, delay: index * 0.1 }}
-                className="bg-slate-600 rounded-xl p-6 border border-slate-600 flex gap-4 items-start hover:border-cyan-500/40 transition-colors duration-300"
+                className="bg-slate-600 rounded-md p-6 border border-slate-600 flex gap-4 items-start hover:border-cyan-500/40 transition-colors duration-300"
               >
                 <div className="flex-shrink-0 w-12 h-12 bg-slate-600 rounded-full flex items-center justify-center">
                   {target.icon}
@@ -227,7 +227,7 @@ const ProgrammingSchoolContent = () => {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.5, delay: index * 0.15 }}
-                className="flex-1 rounded-2xl overflow-hidden border border-slate-600 bg-slate-700"
+                className="flex-1 rounded-lg overflow-hidden border border-slate-600 bg-slate-700"
               >
                 <div className="px-5 py-3 bg-slate-600 font-bold text-sm flex justify-between items-center">
                   <span className="text-cyan-400">{level.step}</span>
@@ -317,7 +317,7 @@ const ProgrammingSchoolContent = () => {
                 transition={{ duration: 0.5, delay: index * 0.1 }}
                 className="flex flex-col"
               >
-                <div className="bg-slate-700 rounded-2xl rounded-tl-none p-5 flex-1 border border-slate-600">
+                <div className="bg-slate-700 rounded-lg rounded-tl-none p-5 flex-1 border border-slate-600">
                   <p className="text-zinc-300 text-sm leading-relaxed">{voice.text}</p>
                 </div>
                 <div className="mt-3 pl-4 text-xs text-zinc-600">{voice.attr}</div>
@@ -349,7 +349,7 @@ const ProgrammingSchoolContent = () => {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.4, delay: index * 0.06 }}
-                className="border border-slate-600 bg-slate-700 rounded-xl overflow-hidden"
+                className="border border-slate-600 bg-slate-700 rounded-md overflow-hidden"
               >
                 <button
                   onClick={() => setOpenFaq(openFaq === index ? null : index)}

--- a/src/app/services/web-development/_WebDevelopmentContent.tsx
+++ b/src/app/services/web-development/_WebDevelopmentContent.tsx
@@ -138,7 +138,7 @@ const WebDevelopmentContent = () => {
               transition={{ duration: 0.7, delay: 0.2 }}
               className="flex-shrink-0 w-full max-w-xs lg:max-w-sm"
             >
-              <div className="bg-white rounded-xl overflow-hidden shadow-lg border border-gray-200">
+              <div className="bg-white rounded-md overflow-hidden shadow-lg border border-gray-200">
                 <div className="flex items-center gap-2 px-4 py-3 bg-gray-100">
                   <div className="w-3 h-3 rounded-full bg-red-400" />
                   <div className="w-3 h-3 rounded-full bg-yellow-400" />
@@ -197,7 +197,7 @@ const WebDevelopmentContent = () => {
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -10 }}
               transition={{ duration: 0.3 }}
-              className="bg-white rounded-2xl p-8 shadow-sm border border-gray-100"
+              className="bg-white rounded-lg p-8 shadow-sm border border-gray-100"
             >
               <h3 className="text-xl font-bold text-gray-900 mb-3">{serviceTypes[activeTab].title}</h3>
               <p className="text-gray-600 leading-relaxed mb-6">{serviceTypes[activeTab].description}</p>
@@ -236,7 +236,7 @@ const WebDevelopmentContent = () => {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.5, delay: index * 0.1 }}
-                className="relative p-6 rounded-xl border border-slate-200 bg-white shadow-sm hover:border-cyan-400 hover:shadow-md transition-all duration-300 overflow-hidden"
+                className="relative p-6 rounded-md border border-slate-200 bg-white shadow-sm hover:border-cyan-400 hover:shadow-md transition-all duration-300 overflow-hidden"
               >
                 <span className="absolute top-3 right-4 text-6xl font-black text-slate-100 select-none leading-none">
                   {item.num}
@@ -332,7 +332,7 @@ const WebDevelopmentContent = () => {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.4, delay: index * 0.06 }}
-                className="border border-gray-200 rounded-xl overflow-hidden"
+                className="border border-gray-200 rounded-md overflow-hidden"
               >
                 <button
                   onClick={() => setOpenFaq(openFaq === index ? null : index)}

--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -70,7 +70,7 @@ const Benefits = () => {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.5, delay: index * 0.1 }}
-              className="group relative flex flex-col gap-6 p-8 rounded-2xl border border-gray-100 hover:border-cyan-200 hover:shadow-lg hover:shadow-cyan-50 transition-all duration-300 bg-white"
+              className="group relative flex flex-col gap-6 p-8 rounded-lg border border-gray-100 hover:border-cyan-200 hover:shadow-lg hover:shadow-cyan-50 transition-all duration-300 bg-white"
             >
               {/* 番号 */}
               <span className="absolute top-6 right-6 text-4xl font-black text-gray-100 leading-none select-none group-hover:text-cyan-50 transition-colors">
@@ -78,7 +78,7 @@ const Benefits = () => {
               </span>
 
               {/* アイコン */}
-              <div className="relative z-10 w-12 h-12 flex items-center justify-center rounded-2xl bg-cyan-600 text-white group-hover:bg-cyan-700 transition-colors duration-300">
+              <div className="relative z-10 w-12 h-12 flex items-center justify-center rounded-lg bg-cyan-600 text-white group-hover:bg-cyan-700 transition-colors duration-300">
                 {benefit.icon}
               </div>
 

--- a/src/components/CompanyInfo.tsx
+++ b/src/components/CompanyInfo.tsx
@@ -52,7 +52,7 @@ const CompanyInfo = () => {
         <div className="flex flex-col lg:flex-row gap-10 lg:gap-16">
           {/* マップ */}
           <div className="w-full lg:w-1/2 shrink-0">
-            <div className="rounded-2xl overflow-hidden border border-gray-100 shadow-sm">
+            <div className="rounded-lg overflow-hidden border border-gray-100 shadow-sm">
               <iframe
                 src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d6635.037567898468!2d129.67908911499234!3d33.74725761365943!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x356a152dd77d1c2b%3A0xf76c730b62764b90!2z44CSODExLTUxMzUg6ZW35bSO55yM5aOx5bKQ5biC6YO344OO5rWm55S66YO344OO5rWm!5e0!3m2!1sja!2sjp!4v1723188274913!5m2!1sja!2sjp"
                 width="100%"

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -34,7 +34,7 @@ function ResourceTable() {
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="rounded-2xl overflow-hidden border border-gray-200 bg-white">
+      <div className="rounded-lg overflow-hidden border border-gray-200 bg-white">
         <table className="w-full text-sm border-collapse">
           <thead>
             <tr className="bg-gray-100">
@@ -219,7 +219,7 @@ export default function Component() {
               ].map((item) => (
                 <div
                   key={item.title}
-                  className="flex gap-3 p-4 rounded-xl bg-white border border-gray-100"
+                  className="flex gap-3 p-4 rounded-md bg-white border border-gray-100"
                 >
                   <div className="shrink-0 w-8 h-8 flex items-center justify-center rounded-lg bg-cyan-50">
                     {item.icon}
@@ -236,7 +236,7 @@ export default function Component() {
               ))}
 
               {/* LINE友だち追加 */}
-              <div className="flex gap-3 p-4 rounded-xl bg-white border border-gray-100">
+              <div className="flex gap-3 p-4 rounded-md bg-white border border-gray-100">
                 <div className="shrink-0 w-8 h-8 flex items-center justify-center rounded-lg bg-green-50">
                   <svg
                     className="w-4 h-4 text-green-500"
@@ -261,7 +261,7 @@ export default function Component() {
 
           {/* 右側：フォーム */}
           <div className="flex-1" id="contact-form">
-            <div className="bg-white rounded-2xl border border-gray-100 p-8">
+            <div className="bg-white rounded-lg border border-gray-100 p-8">
               <form
                 ref={formRef}
                 className="flex flex-col gap-6"
@@ -358,7 +358,7 @@ export default function Component() {
       {/* 確認モーダル */}
       {showModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-          <div className="bg-white rounded-2xl shadow-2xl p-8 max-w-sm w-full mx-4">
+          <div className="bg-white rounded-lg shadow-2xl p-8 max-w-sm w-full mx-4">
             <div className="flex justify-between items-center mb-4">
               <h3 className="text-lg font-bold text-gray-950">送信確認</h3>
               <button

--- a/src/components/CtaBanner.tsx
+++ b/src/components/CtaBanner.tsx
@@ -13,7 +13,7 @@ const CtaBanner = () => {
       className="py-24 px-6"
     >
       <div className="max-w-4xl mx-auto">
-        <div className="rounded-3xl bg-gray-950 px-8 py-16 md:px-16 text-center flex flex-col items-center gap-8 relative overflow-hidden">
+        <div className="rounded-lg bg-gray-950 px-8 py-16 md:px-16 text-center flex flex-col items-center gap-8 relative overflow-hidden">
           {/* 背景装飾 */}
           <div className="absolute top-0 left-1/2 -translate-x-1/2 w-96 h-96 bg-cyan-600/10 rounded-full blur-3xl pointer-events-none" />
 

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -140,7 +140,7 @@ const Hero = () => {
             className="flex-1 relative w-full max-w-xl lg:max-w-none"
           >
             <div className="relative">
-              <div className="relative z-10 rounded-3xl overflow-hidden bg-gray-50">
+              <div className="relative z-10 rounded-lg overflow-hidden bg-gray-50">
                 <Image
                   src="/hero.png"
                   alt="Hero画像"

--- a/src/components/IntroScreen.tsx
+++ b/src/components/IntroScreen.tsx
@@ -89,7 +89,7 @@ export default function IntroScreen() {
             initial={{ opacity: 0, scale: 0.96, y: 16 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             transition={{ duration: 0.5, ease: "easeOut" }}
-            className="relative w-full max-w-xl mx-4 rounded-2xl overflow-hidden shadow-2xl border border-gray-700/60"
+            className="relative w-full max-w-xl mx-4 rounded-lg overflow-hidden shadow-2xl border border-gray-700/60"
             style={{ background: "#0f172a" }}
           >
             {/* タイトルバー */}

--- a/src/components/Member.tsx
+++ b/src/components/Member.tsx
@@ -33,11 +33,11 @@ const Member = () => {
           {members.map((member) => (
             <div
               key={member.name}
-              className="flex flex-col md:flex-row gap-8 md:gap-12 items-start bg-white rounded-2xl p-8 border border-gray-100"
+              className="flex flex-col md:flex-row gap-8 md:gap-12 items-start bg-white rounded-lg p-8 border border-gray-100"
             >
               {/* 画像 */}
               <div className="shrink-0">
-                <div className="w-24 h-24 md:w-32 md:h-32 rounded-2xl overflow-hidden bg-gray-100">
+                <div className="w-24 h-24 md:w-32 md:h-32 rounded-lg overflow-hidden bg-gray-100">
                   <Image
                     alt={member.name}
                     src={member.image}

--- a/src/components/News.tsx
+++ b/src/components/News.tsx
@@ -40,7 +40,7 @@ const News = async () => {
               <Link
                 key={id}
                 href={`/news/${news.id}`}
-                className="group flex flex-col sm:flex-row sm:items-center gap-4 py-6 hover:bg-gray-50/80 -mx-4 px-4 rounded-xl transition-colors duration-200"
+                className="group flex flex-col sm:flex-row sm:items-center gap-4 py-6 hover:bg-gray-50/80 -mx-4 px-4 rounded-md transition-colors duration-200"
               >
                 <time
                   className="shrink-0 text-sm font-medium text-gray-400 w-28"
@@ -56,7 +56,7 @@ const News = async () => {
             ))}
           </div>
         ) : (
-          <div className="rounded-2xl border border-dashed border-gray-200 bg-gray-50 py-20 px-6 flex flex-col items-center gap-3">
+          <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 py-20 px-6 flex flex-col items-center gap-3">
             <p className="text-lg font-bold text-gray-400">Coming soon...</p>
             <p className="text-sm text-gray-400">
               新着情報は現在準備中です。公開までお待ちください。

--- a/src/components/Problem.tsx
+++ b/src/components/Problem.tsx
@@ -66,12 +66,12 @@ const Problem = () => {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.5, delay: index * 0.08 }}
-              className="bg-gray-50 p-8 rounded-2xl group hover:bg-gray-100 transition-colors duration-300"
+              className="bg-gray-50 p-8 rounded-lg group hover:bg-gray-100 transition-colors duration-300"
             >
               <div className="flex flex-col gap-4">
                 {/* 番号 + アイコン */}
                 <div className="flex items-center justify-between">
-                  <div className="w-10 h-10 flex items-center justify-center rounded-xl bg-cyan-50 border border-cyan-100 group-hover:border-cyan-300 transition-colors duration-300">
+                  <div className="w-10 h-10 flex items-center justify-center rounded-md bg-cyan-50 border border-cyan-100 group-hover:border-cyan-300 transition-colors duration-300">
                     {problem.icon}
                   </div>
                   <span className="text-5xl font-black text-gray-200 leading-none select-none group-hover:text-gray-300 transition-colors">

--- a/src/components/Service.tsx
+++ b/src/components/Service.tsx
@@ -58,7 +58,7 @@ const ServiceCard = ({
   index: number;
 }) => {
   const cardContent = (
-    <div className="group relative flex flex-col h-full rounded-2xl overflow-hidden border border-gray-100 hover:border-gray-200 bg-white hover:shadow-xl hover:shadow-gray-100/80 transition-all duration-500">
+    <div className="group relative flex flex-col h-full rounded-lg overflow-hidden border border-gray-100 hover:border-gray-200 bg-white hover:shadow-xl hover:shadow-gray-100/80 transition-all duration-500">
       {/* 画像 */}
       <div className="relative h-48 overflow-hidden bg-gray-100 shrink-0">
         <Image


### PR DESCRIPTION
## Summary

- `globals.css` の CSS変数 `--radius` を `0.5rem` → `0.25rem` に変更
- 全ページ・全コンポーネントで `rounded-2xl` / `rounded-3xl` / `rounded-xl` を `rounded-lg` / `rounded-md` に統一
- 対象: Hero, Benefits, Problem, Service, News, Member, CompanyInfo, Contact, CtaBanner, IntroScreen, About, NewsDetail, NewsList, 各サービスページ (DX・AI支援 / ITトレーニング / プログラミングスクール / Web開発)

## Test plan

- [ ] トップページ各セクション（Hero・Benefits・Problem・Service・News・CtaBanner）の角丸が適切に小さくなっていること
- [ ] About・Newsページの角丸が統一されていること
- [ ] 各サービスページのカード・モーダル・FAQ等の角丸が統一されていること
- [ ] モバイル・タブレット・デスクトップ各ブレークポイントで崩れがないこと