### PR TITLE
Claude Code に確認待ち・作業完了の macOS 通知フックを追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,28 @@
           }
         ]
       }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "osascript -e 'display notification \"Claude Code が確認待ちです\" with title \"Claude Code\" sound name \"Glass\"'"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "osascript -e 'display notification \"作業が完了しました\" with title \"Claude Code\" sound name \"Ping\"'"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

- `Notification` フック: Claude Code が確認待ちになったとき macOS 通知（Glassサウンド）を表示
- `Stop` フック: Claude Code が作業を完了したとき macOS 通知（Pingサウンド）を表示

## Test plan

- [ ] Claude Code を起動し、確認待ち状態になったときに通知が届くことを確認
- [ ] Claude Code の応答が完了したときに通知が届くことを確認
- [ ] サウンドが正常に再生されることを確認（Glass / Ping）