### PR TITLE
Serena MCP サーバーのプロジェクト設定とメモリを追加

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/memories/conventions.md
+++ b/.serena/memories/conventions.md
@@ -1,0 +1,32 @@
+# Conventions
+
+## ファイル・命名
+- コンポーネントファイル: PascalCase (`Hero.tsx`, `Footer.tsx`)
+- ユーティリティ・ライブラリ: camelCase (`featureFlags.ts`, `microcms.ts`)
+- パスエイリアス `@/*` → `src/*` を常に使用
+
+## コンポーネント
+- `src/components/ui/` — Radix UI ベースの汎用 UI（shadcn/ui パターン）、`class-variance-authority` で variant 管理
+- `src/components/` — ページセクション単位のコンポーネント（Hero, Footer, Header 等）
+- Server Components をデフォルト、クライアント操作が必要な箇所のみ `"use client"`
+
+## スタイル
+- Tailwind CSS ユーティリティクラス主体
+- `tailwind-merge` + `clsx` で条件付きクラス結合 (`cn()` ユーティリティが `src/lib/utils.ts` に存在)
+- 角丸はシャープなスタイルに統一（recent commit 参照）
+
+## 機能フラグ
+- `featureFlags` オブジェクト (`src/lib/featureFlags.ts`) で環境変数から boolean に変換
+- `getServiceUrl(enabled, url)` で `null` または URL を返す
+- 無効サービスは `/coming-soon` リダイレクトせず `null` を返す（UI 側でリンクを非表示にする）
+
+## SEO
+- `src/lib/seo.tsx` のユーティリティでメタタグ生成
+- `src/config.ts` の定数を参照
+
+## ISR / キャッシュ
+- microCMS の fetch は `next: { tags: ['news'] }` タグ付きキャッシュ
+- `src/app/api/revalidate/` で Webhook による `revalidateTag('news')` 実装
+
+## バリデーション
+- `src/schemas/` に Zod スキーマを配置、フォーム入力の検証に使用

--- a/.serena/memories/core.md
+++ b/.serena/memories/core.md
@@ -1,0 +1,39 @@
+# Core — IKI Digital Lab. Website
+
+企業サイト。Next.js 14 App Router + TypeScript + Tailwind CSS。
+
+## Source Map
+
+```
+src/
+  app/          # Next.js App Router pages & API routes
+    page.tsx    # トップページ（ランディングページ）
+    layout.tsx  # ルートレイアウト
+    services/   # サービスページ (dx-ai-support, web-development, programming-school, it-training)
+    news/       # ニュース一覧・詳細
+    api/revalidate/  # microCMS Webhook による ISR 再検証
+    about/, coming-soon/, privacy-policy/, tos/, colors/
+  components/   # ページセクションコンポーネント (Hero, Header, Footer, Service 等)
+    ui/         # shadcn/ui パターンの汎用コンポーネント (Radix UI ベース)
+  lib/
+    microcms.ts   # microCMS SDK クライアント・News/Contact 型・fetch 関数
+    featureFlags.ts  # サービスページ公開フラグ管理
+    seo.tsx       # メタタグ生成ユーティリティ
+    utils.ts
+  config.ts     # appName, appDescription, domainName, navLinks 等の定数
+  schemas/      # Zod バリデーションスキーマ
+  actions/      # Server Actions
+  test/         # Vitest セットアップ
+  types/
+types/          # グローバル型定義
+```
+
+## Project-wide Invariants
+
+- パスエイリアス `@/*` → `src/*`
+- アプリ名: "IKI Digital Lab."
+- デプロイ先: Vercel (`iki-digital.vercel.app`)
+- コンテンツ管理: microCMS（ニュース記事）
+- feature flag が `false` のサービスは `null` を返す（`/coming-soon` リダイレクトは一時停止中）
+
+詳細は `mem:tech_stack`, `mem:conventions`, `mem:suggested_commands`, `mem:task_completion` を参照。

--- a/.serena/memories/memory_maintenance.md
+++ b/.serena/memories/memory_maintenance.md
@@ -1,0 +1,33 @@
+# Memory Maintenance
+
+## Discovery Model
+
+- Core principle: progressive discovery through references, building a graph of memories.
+- Initially, agents are provided with the list of all memories (names only).
+- Agents should read `mem:core` as the top-level entry point (graph root).
+  This memory should contain references to other memories covering major project domains.
+  The referenced memories shall, in turn, shall contain references to even more specific memories, and so on.
+  The depth of the graph shall depend on the project complexity.
+- Use topics/folders to group related memories in order to make the content structure explicit.
+  Folders can mirror project structure (e.g. modules like frontend/backend) or topics like debugging, architecture, etc.
+- Memory references must use a mem: prefix inside backticks, e.g. `mem:frontend/core`.
+  The surrounding text should clearly indicate when to read the memory/which content to expect.
+  The text should provide more precise guidance than the memory name alone, 
+  i.e. avoid a reference like "frontend debugging: `mem:frontend/debugging` and instead make clear which aspects of frontend debugging are covered.
+- Memories themselves should not contain information about when to read them; this is the responsibility of the referring memory.
+
+## Style
+
+Dense agent notes, not prose docs. Prefer invariants, terse bullets. 
+Avoid obvious context, rationale, and examples unless they prevent likely mistakes. 
+Keep guidance durable and generalizable, not task-local.
+
+## Add/update threshold
+
+Add or update memories only with stable, non-obvious project conventions that avoid complex rediscovery in the future.
+Do not add: quick-read facts; generic language/framework knowledge; one-off task notes; volatile line-level details; behavior likely to change soon.
+
+## Maintenance Actions
+
+- Renaming memories: References are updated automatically if handled via Serena's memory rename tool.
+- Checking for stale memories (e.g. after deletion): Call `serena memories check` for a report.

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,24 @@
+# Suggested Commands
+
+## Development
+```bash
+npm run dev        # 開発サーバー起動 (localhost:3000)
+npm run build      # 本番ビルド (fetch-cache クリア付き: rm -rf .next/cache/fetch-cache && next build)
+npm run start      # 本番サーバー起動
+```
+
+## Linting
+```bash
+npm run lint       # ESLint 実行
+npm run lint:fix   # ESLint 自動修正
+```
+
+## Testing
+```bash
+npm test           # Vitest (watch モード)
+npm run test:run   # Vitest (一回実行)
+```
+
+## Environment
+`.env.local` を `.env.example` を参考に作成する。
+必要な変数: `MICROCMS_SERVICE_DOMAIN`, `MICROCMS_API_KEY`, `NEXT_PUBLIC_FEATURE_*` フラグ群。

--- a/.serena/memories/task_completion.md
+++ b/.serena/memories/task_completion.md
@@ -1,0 +1,22 @@
+# Task Completion
+
+コーディングタスク完了時に実行するコマンド:
+
+```bash
+# 1. 型チェック（TypeScript）
+npx tsc --noEmit
+
+# 2. Lint チェック
+npm run lint
+
+# 3. テスト実行
+npm run test:run
+
+# 4. ビルド確認（必要な場合）
+npm run build
+```
+
+## 注意事項
+- `npm run build` は fetch-cache を削除するため、開発中は通常不要
+- テストファイルは `src/lib/__tests__/` または `src/lib/*.test.ts` に配置
+- Vitest は jsdom 環境で動作、セットアップファイル: `src/test/setup.ts`

--- a/.serena/memories/tech_stack.md
+++ b/.serena/memories/tech_stack.md
@@ -1,0 +1,40 @@
+# Tech Stack
+
+## Runtime & Framework
+- Next.js `^14.2.3` (App Router)
+- React `^18.3.1` / React DOM `^18.3.1`
+- TypeScript `~5.6`
+- Node.js (Darwin)
+
+## Styling
+- Tailwind CSS `^3.4.1` + tailwind-merge + tailwindcss-animate
+- `@tailwindcss/typography`
+- PostCSS
+
+## UI Components
+- Radix UI (`@radix-ui/react-avatar`, `react-label`, `react-slot`, `react-toast`) — shadcn/ui パターン
+- lucide-react (アイコン)
+- framer-motion (アニメーション)
+- next-themes (ダークモード)
+
+## CMS & Data
+- microcms-js-sdk `^3.1.1` — ニュース記事取得・お問い合わせ送信
+- zod `^3.23.8` — バリデーション
+
+## Utilities
+- date-fns `^3.6.0` + date-fns-tz
+- clsx + class-variance-authority
+- html-react-parser
+- highlight.js
+
+## Testing
+- Vitest `^4.1.7` (jsdom 環境)
+- @testing-library/react `^16.3.2`
+- @testing-library/jest-dom + user-event
+
+## Linting
+- ESLint `^8` + eslint-config-next + @typescript-eslint + @stylistic/eslint-plugin
+
+## Build
+- `npm` (package manager)
+- fetch-cache を `rm -rf .next/cache/fetch-cache` してからビルド

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,133 @@
+# the name by which the project can be referenced within Serena
+project_name: "IKIDigitalLab-website"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- typescript
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []


### PR DESCRIPTION
## Summary

- `.serena/project.yml` にプロジェクト言語・エンコーディング等の設定を追加
- `.serena/memories/` にアーキテクチャ・規約・技術スタック等のコンテキストメモリを追加
- `.serena/.gitignore` でキャッシュとローカル設定を除外

## Test plan

- [ ] `npm run build` が正常に完了すること
- [ ] `npm run lint` でエラーがないこと