### PR TITLE
About ページの「運営」見出しを「メンバー」に変更

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -145,7 +145,7 @@ const AboutPage = () => {
               </span>
             </div>
             <h2 className="text-3xl md:text-4xl font-bold text-gray-950 leading-tight">
-              運営
+              メンバー
             </h2>
           </div>
 


### PR DESCRIPTION
## Summary
- `src/app/about/page.tsx` の見出しテキストを「運営」→「メンバー」に変更

## Test plan
- [ ] About ページを表示し、メンバーセクションの見出しが「メンバー」と表示されることを確認