### PR TITLE
ヘッダー・各セクションの UI 調整

### DIFF
--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -70,7 +70,7 @@ const Benefits = () => {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.5, delay: index * 0.1 }}
-              className="group relative flex flex-col gap-6 p-8 rounded-lg border border-gray-100 hover:border-cyan-200 hover:shadow-lg hover:shadow-cyan-50 transition-all duration-300 bg-white"
+              className="group relative flex flex-col gap-6 p-8 border border-gray-100 hover:border-cyan-200 hover:shadow-lg hover:shadow-cyan-50 transition-all duration-300 bg-white"
             >
               {/* 番号 */}
               <span className="absolute top-6 right-6 text-4xl font-black text-gray-100 leading-none select-none group-hover:text-cyan-50 transition-colors">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,7 +8,7 @@ import Image from "next/image";
 import LineAddFriendButton from "@/components/LineAddFriendButton";
 
 const navLinks = [
-  { label: "トップ", to: "hero", href: "/" },
+  { label: "ホーム", to: "hero", href: "/" },
   { label: "サービス", to: "service", href: "/#service" },
   { label: "お知らせ", to: "news", href: "/news" },
   { label: "運営概要", to: "company-info", href: "/#company-info" },

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,7 +10,7 @@ import config from "@/config";
 import { motion, useAnimation, AnimatePresence } from "framer-motion";
 
 const navLinks = [
-  { label: "トップ", to: "hero", href: "/" },
+  { label: "ホーム", to: "hero", href: "/" },
   { label: "サービス", to: "service", href: "/#service" },
   { label: "お知らせ", to: "news", href: "/news" },
   { label: "運営概要", to: null, href: "/about" },
@@ -66,14 +66,14 @@ const Header = () => {
         }`}
       >
         <nav
-          className="max-w-6xl mx-auto px-6 lg:px-12 flex items-center justify-between h-16"
+          className="max-w-6xl mx-auto px-6 lg:px-12 flex items-stretch justify-between h-16"
           aria-label="Global"
         >
           {/* ロゴ */}
           <Link
             href="/"
             title={config.appName}
-            className="flex items-center gap-2 shrink-0"
+            className="flex items-center gap-2 shrink-0 self-center"
           >
             <Image
               alt="Logo"
@@ -88,7 +88,7 @@ const Header = () => {
           </Link>
 
           {/* デスクトップナビ */}
-          <div className="hidden md:flex items-center gap-8">
+          <div className="hidden md:flex items-center gap-8 self-center">
             {navLinks.map(({ label, to, href }) => {
               const linkClass =
                 "text-sm font-medium text-gray-600 hover:text-gray-950 transition-colors duration-200";
@@ -111,21 +111,24 @@ const Header = () => {
                 </Link>
               );
             })}
+          </div>
 
+          {/* お問い合わせボタン（ヘッダーと同高さ） */}
+          <div className="hidden md:flex self-stretch">
             {pathname === "/" ? (
-              <Scroll to="contact" smooth={true} offset={-100}>
+              <Scroll to="contact" smooth={true} offset={-100} className="flex items-stretch">
                 <Button
                   size="sm"
-                  className="rounded-sm px-5 bg-gray-950 text-white hover:bg-gray-800 transition-all duration-300 font-semibold"
+                  className="h-full rounded-none px-6 bg-gray-950 text-white hover:bg-gray-800 transition-all duration-300 font-semibold"
                 >
                   お問い合わせ
                 </Button>
               </Scroll>
             ) : (
-              <Link href="/#contact">
+              <Link href="/#contact" className="flex items-stretch">
                 <Button
                   size="sm"
-                  className="rounded-sm px-5 bg-gray-950 text-white hover:bg-gray-800 transition-all duration-300 font-semibold"
+                  className="h-full rounded-none px-6 bg-gray-950 text-white hover:bg-gray-800 transition-all duration-300 font-semibold"
                 >
                   お問い合わせ
                 </Button>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -89,14 +89,6 @@ const Hero = () => {
               transition={{ duration: 0.6, delay: 0.45 }}
               className="flex flex-col sm:flex-row gap-3"
             >
-              <Scroll to="contact" smooth={true} offset={-100}>
-                <Button
-                  size="lg"
-                  className="bg-gray-950 text-white hover:bg-gray-800 transition-all duration-300 px-8 rounded-sm font-semibold tracking-wide"
-                >
-                  お問い合わせ
-                </Button>
-              </Scroll>
               <Scroll to="service" smooth={true} offset={-80}>
                 <Button
                   size="lg"


### PR DESCRIPTION
## Summary

- ヘッダーのお問い合わせボタンをヘッダーと同高さ（h-16）のフルハイトボタンに変更
- ヘッダー・フッターのナビリンク「トップ」を「ホーム」に統一
- Benefits カードの角丸（`rounded-lg`）を削除してシャープな見た目に
- Hero セクションの「お問い合わせ」CTA ボタンを削除（ヘッダーに常設のため重複解消）

## Test plan

- [ ] ヘッダーのお問い合わせボタンがヘッダーと同じ高さで表示されること
- [ ] ヘッダー・フッターのナビに「ホーム」と表示されること
- [ ] Benefits カードの角が直角になっていること
- [ ] Hero セクションに「サービスを見る」ボタンのみ表示されること
- [ ] モバイル表示でレイアウトが崩れていないこと